### PR TITLE
feat: v2 UI enhancements — stats chart, date grouping, About screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,10 +17,20 @@ android {
         versionName = "2.0.0"
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file("${System.getProperty("user.home")}/.android/debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 

--- a/app/src/main/kotlin/com/nil/behisebe/ui/components/ExpenseItem.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/components/ExpenseItem.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nil.behisebe.data.model.ExpenseWithCategory
 import com.nil.behisebe.utils.toCurrency
-import com.nil.behisebe.utils.toDisplayDate
 
 @Composable
 fun ExpenseItem(
@@ -71,11 +70,6 @@ fun ExpenseItem(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            Text(
-                text = item.expense.date.toDisplayDate(),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
         }
 
         Text(

--- a/app/src/main/kotlin/com/nil/behisebe/ui/components/WeekBarChart.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/components/WeekBarChart.kt
@@ -1,0 +1,111 @@
+package com.nil.behisebe.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.nil.behisebe.ui.screens.stats.DayTotal
+import com.nil.behisebe.utils.toIso
+import java.time.LocalDate
+
+@Composable
+fun WeekBarChart(
+    days: List<DayTotal>,
+    modifier: Modifier = Modifier,
+) {
+    if (days.isEmpty()) return
+
+    val today = LocalDate.now().toIso()
+    val maxAmount = days.maxOf { it.amount }.takeIf { it > 0.0 } ?: 1.0
+
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val barColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f)
+    val trackColor = MaterialTheme.colorScheme.surfaceVariant
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.Bottom,
+    ) {
+        days.forEach { day ->
+            val fraction = (day.amount / maxAmount).toFloat().coerceIn(0f, 1f)
+            val isToday = day.date == today
+            val color = if (isToday) primaryColor else barColor
+
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                // Amount label above bar (only when non-zero)
+                if (day.amount > 0.0) {
+                    Text(
+                        text = "₹${"%,.0f".format(day.amount)}",
+                        fontSize = 8.sp,
+                        color = if (isToday) primaryColor else MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                        maxLines = 1,
+                    )
+                } else {
+                    Text(text = "", fontSize = 8.sp) // placeholder to keep alignment
+                }
+
+                // Bar
+                Canvas(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(80.dp)
+                ) {
+                    val barWidth = size.width
+                    val totalHeight = size.height
+                    val minBarHeight = 4.dp.toPx()
+                    val barHeight = (fraction * totalHeight).coerceAtLeast(
+                        if (day.amount > 0) minBarHeight else 0f
+                    )
+                    val cornerRadius = CornerRadius(4.dp.toPx())
+
+                    // Track (background)
+                    drawRoundRect(
+                        color = trackColor,
+                        topLeft = Offset(0f, 0f),
+                        size = Size(barWidth, totalHeight),
+                        cornerRadius = cornerRadius,
+                    )
+
+                    // Bar fill (from bottom)
+                    if (barHeight > 0f) {
+                        drawRoundRect(
+                            color = color,
+                            topLeft = Offset(0f, totalHeight - barHeight),
+                            size = Size(barWidth, barHeight),
+                            cornerRadius = cornerRadius,
+                        )
+                    }
+                }
+
+                // Day label
+                Text(
+                    text = day.label.take(3),
+                    fontSize = 10.sp,
+                    color = if (isToday) primaryColor else MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/nil/behisebe/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/navigation/AppNavigation.kt
@@ -22,6 +22,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.nil.behisebe.ui.screens.about.AboutScreen
 import com.nil.behisebe.ui.screens.addedit.AddEditScreen
 import com.nil.behisebe.ui.screens.categories.CategoriesScreen
 import com.nil.behisebe.ui.screens.home.HomeScreen
@@ -32,6 +33,7 @@ sealed class Screen(val route: String, val label: String) {
     object Stats : Screen("stats", "Stats")
     object Categories : Screen("categories", "Categories")
     object AddEdit : Screen("add_edit?expenseId={expenseId}", "Add")
+    object About : Screen("about", "About")
 }
 
 @Composable
@@ -84,6 +86,7 @@ fun AppNavigation() {
                 HomeScreen(
                     onAddExpense = { navController.navigate("add_edit") },
                     onEditExpense = { id -> navController.navigate("add_edit?expenseId=$id") },
+                    onAbout = { navController.navigate(Screen.About.route) },
                 )
             }
             composable(Screen.Stats.route) {
@@ -104,6 +107,9 @@ fun AppNavigation() {
                     expenseId = if (expenseId == -1L) null else expenseId,
                     onDone = { navController.popBackStack() },
                 )
+            }
+            composable(Screen.About.route) {
+                AboutScreen(onBack = { navController.popBackStack() })
             }
         }
     }

--- a/app/src/main/kotlin/com/nil/behisebe/ui/screens/about/AboutScreen.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/screens/about/AboutScreen.kt
@@ -1,0 +1,162 @@
+package com.nil.behisebe.ui.screens.about
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountBalanceWallet
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutScreen(onBack: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("About") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            // App icon + name
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.AccountBalanceWallet,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(40.dp),
+                )
+            }
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = "Behisebe",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = "Version 2.0.0",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "Your personal expense tracker",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+            )
+
+            Spacer(Modifier.height(32.dp))
+
+            // Info cards
+            InfoCard {
+                InfoRow(label = "App name", value = "Behisebe")
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                InfoRow(label = "Version", value = "2.0.0 (build 1)")
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                InfoRow(label = "Platform", value = "Android")
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                InfoRow(label = "Storage", value = "Local only (offline)")
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            InfoCard {
+                InfoRow(label = "Developer", value = "Nil")
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                InfoRow(label = "Language", value = "Kotlin + Jetpack Compose")
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                InfoRow(label = "Database", value = "Room / SQLite")
+            }
+
+            Spacer(Modifier.height(32.dp))
+
+            Text(
+                text = "Behisebe (হিসেবে) means \"accountant\" — a simple, private, offline-first expense tracker.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                lineHeight = 18.sp,
+            )
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun InfoCard(content: @Composable () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun InfoRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/nil/behisebe/ui/screens/categories/CategoriesScreen.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/screens/categories/CategoriesScreen.kt
@@ -2,7 +2,6 @@ package com.nil.behisebe.ui.screens.categories
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,7 +34,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -47,11 +45,6 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.nil.behisebe.data.model.Category
-
-private val presetColors = listOf(
-    0xFFFF6B6B, 0xFF4ECDC4, 0xFFA78BFA, 0xFF34D399,
-    0xFFFB923C, 0xFF60A5FA, 0xFF94A3B8, 0xFFF472B6,
-).map { it.toInt() }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -100,8 +93,8 @@ fun CategoriesScreen(viewModel: CategoriesViewModel = viewModel()) {
             title = "New Category",
             confirmLabel = "Add",
             onDismiss = { showAddDialog = false },
-            onConfirm = { name, icon, color ->
-                viewModel.addCategory(name, icon, color)
+            onConfirm = { name, icon ->
+                viewModel.addCategory(name, icon)
                 showAddDialog = false
             }
         )
@@ -113,10 +106,9 @@ fun CategoriesScreen(viewModel: CategoriesViewModel = viewModel()) {
             confirmLabel = "Save",
             initialName = cat.name,
             initialIcon = cat.icon,
-            initialColor = cat.color,
             onDismiss = { editingCategory = null },
-            onConfirm = { name, icon, color ->
-                viewModel.updateCategory(cat.copy(name = name, icon = icon, color = color))
+            onConfirm = { name, icon ->
+                viewModel.updateCategory(cat.copy(name = name, icon = icon))
                 editingCategory = null
             }
         )
@@ -165,13 +157,11 @@ private fun CategoryDialog(
     confirmLabel: String,
     initialName: String = "",
     initialIcon: String = "📦",
-    initialColor: Int = presetColors.first(),
     onDismiss: () -> Unit,
-    onConfirm: (name: String, icon: String, color: Int) -> Unit,
+    onConfirm: (name: String, icon: String) -> Unit,
 ) {
     var name by remember { mutableStateOf(initialName) }
     var icon by remember { mutableStateOf(initialIcon) }
-    var selectedColor by remember { mutableIntStateOf(initialColor) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -192,28 +182,11 @@ private fun CategoryDialog(
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                 )
-                Text("Color", style = MaterialTheme.typography.labelMedium)
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    presetColors.forEach { color ->
-                        val isSelected = color == selectedColor
-                        Box(
-                            modifier = Modifier
-                                .size(if (isSelected) 34.dp else 28.dp)
-                                .clip(CircleShape)
-                                .background(Color(color))
-                                .clickable(
-                                    indication = null,
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    onClick = { selectedColor = color },
-                                ),
-                        )
-                    }
-                }
             }
         },
         confirmButton = {
             TextButton(
-                onClick = { if (name.isNotBlank()) onConfirm(name.trim(), icon.trim(), selectedColor) },
+                onClick = { if (name.isNotBlank()) onConfirm(name.trim(), icon.trim()) },
                 enabled = name.isNotBlank(),
             ) { Text(confirmLabel) }
         },

--- a/app/src/main/kotlin/com/nil/behisebe/ui/screens/categories/CategoriesViewModel.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/screens/categories/CategoriesViewModel.kt
@@ -10,13 +10,22 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+private val palette = listOf(
+    0xFFFF6B6B, 0xFF4ECDC4, 0xFFA78BFA, 0xFF34D399,
+    0xFFFB923C, 0xFF60A5FA, 0xFF94A3B8, 0xFFF472B6,
+    0xFFE879F9, 0xFF2DD4BF, 0xFFFBBF24, 0xFF6366F1,
+).map { it.toInt() }
+
 class CategoriesViewModel(app: Application) : AndroidViewModel(app) {
     private val repo: CategoryRepository = (app as BehisebeApp).categoryRepository
 
     val categories = repo.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    fun addCategory(name: String, icon: String, color: Int) {
+    fun addCategory(name: String, icon: String) {
+        val usedColors = categories.value.map { it.color }.toSet()
+        val color = palette.firstOrNull { it !in usedColors }
+            ?: palette[categories.value.size % palette.size]
         viewModelScope.launch {
             repo.insert(Category(name = name, icon = icon, color = color))
         }

--- a/app/src/main/kotlin/com/nil/behisebe/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/screens/home/HomeScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.stickyHeader
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -40,6 +41,7 @@ import com.nil.behisebe.ui.components.ExpenseItem
 import com.nil.behisebe.utils.toCurrency
 import com.nil.behisebe.utils.toDisplayDate
 import com.nil.behisebe.utils.toDisplayMonth
+import com.nil.behisebe.utils.toIso
 import java.time.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -158,19 +160,54 @@ fun HomeScreen(
                     )
                 }
             } else {
+                val today = LocalDate.now().toIso()
+                val yesterday = LocalDate.now().minusDays(1).toIso()
+                val grouped = state.expenses
+                    .groupBy { it.expense.date }
+                    .toSortedMap(reverseOrder())
+
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = androidx.compose.foundation.layout.PaddingValues(
                         horizontal = 16.dp, vertical = 8.dp
                     ),
                 ) {
-                    items(state.expenses, key = { it.expense.id }) { item ->
-                        ExpenseItem(
-                            item = item,
-                            onClick = { onEditExpense(item.expense.id) },
-                            onDelete = { viewModel.deleteExpense(item.expense) },
-                        )
+                    grouped.forEach { (date, expensesForDate) ->
+                        stickyHeader(key = "header_$date") {
+                            val label = when (date) {
+                                today -> "Today"
+                                yesterday -> "Yesterday"
+                                else -> date.toDisplayDate()
+                            }
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(MaterialTheme.colorScheme.background)
+                                    .padding(vertical = 8.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = label,
+                                    style = MaterialTheme.typography.labelLarge,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Text(
+                                    text = expensesForDate.sumOf { it.expense.amount }.toCurrency(),
+                                    style = MaterialTheme.typography.labelLarge,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                        items(expensesForDate, key = { it.expense.id }) { item ->
+                            ExpenseItem(
+                                item = item,
+                                onClick = { onEditExpense(item.expense.id) },
+                                onDelete = { viewModel.deleteExpense(item.expense) },
+                            )
+                            Spacer(Modifier.height(8.dp))
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/nil/behisebe/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/screens/home/HomeScreen.kt
@@ -11,17 +11,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.stickyHeader
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -44,11 +46,12 @@ import com.nil.behisebe.utils.toDisplayMonth
 import com.nil.behisebe.utils.toIso
 import java.time.LocalDate
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun HomeScreen(
     onAddExpense: () -> Unit,
     onEditExpense: (Long) -> Unit,
+    onAbout: () -> Unit,
     viewModel: HomeViewModel = viewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
@@ -60,6 +63,11 @@ fun HomeScreen(
             CenterAlignedTopAppBar(
                 title = { Text("Behisebe") },
                 scrollBehavior = scrollBehavior,
+                actions = {
+                    IconButton(onClick = onAbout) {
+                        Icon(Icons.Default.Info, contentDescription = "About")
+                    }
+                },
             )
         },
         floatingActionButton = {

--- a/app/src/main/kotlin/com/nil/behisebe/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/screens/home/HomeScreen.kt
@@ -38,7 +38,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.nil.behisebe.ui.components.ExpenseItem
 import com.nil.behisebe.utils.toCurrency
+import com.nil.behisebe.utils.toDisplayDate
 import com.nil.behisebe.utils.toDisplayMonth
+import java.time.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -112,6 +114,38 @@ fun HomeScreen(
                         color = MaterialTheme.colorScheme.onPrimary,
                     )
                 }
+            }
+
+            // Daily total card
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 8.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column {
+                    Text(
+                        text = "Today",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    )
+                    Text(
+                        text = LocalDate.now().toString().toDisplayDate(),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = state.todayTotal.toCurrency(),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
 
             // Expense list

--- a/app/src/main/kotlin/com/nil/behisebe/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/screens/home/HomeViewModel.kt
@@ -7,6 +7,8 @@ import com.nil.behisebe.BehisebeApp
 import com.nil.behisebe.data.model.Expense
 import com.nil.behisebe.data.model.ExpenseWithCategory
 import com.nil.behisebe.data.repository.ExpenseRepository
+import com.nil.behisebe.utils.toIso
+import java.time.LocalDate
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +22,7 @@ data class HomeUiState(
     val selectedMonth: String = "",
     val expenses: List<ExpenseWithCategory> = emptyList(),
     val monthTotal: Double = 0.0,
+    val todayTotal: Double = 0.0,
 )
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -42,11 +45,13 @@ class HomeViewModel(app: Application) : AndroidViewModel(app) {
             months,
             repo.getByMonthWithCategory(activeMonth),
         ) { monthList, expenses ->
+            val today = LocalDate.now().toIso()
             HomeUiState(
                 months = monthList,
                 selectedMonth = activeMonth,
                 expenses = expenses,
                 monthTotal = expenses.sumOf { it.expense.amount },
+                todayTotal = expenses.filter { it.expense.date == today }.sumOf { it.expense.amount },
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), HomeUiState())

--- a/app/src/main/kotlin/com/nil/behisebe/ui/screens/stats/StatsScreen.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/screens/stats/StatsScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -19,6 +21,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -30,6 +34,9 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,6 +47,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.nil.behisebe.ui.components.DonutChart
 import com.nil.behisebe.ui.components.DonutSlice
+import com.nil.behisebe.ui.components.WeekBarChart
 import com.nil.behisebe.utils.toCurrency
 import com.nil.behisebe.utils.toDisplayMonth
 
@@ -47,6 +55,7 @@ import com.nil.behisebe.utils.toDisplayMonth
 @Composable
 fun StatsScreen(viewModel: StatsViewModel = viewModel()) {
     val state by viewModel.uiState.collectAsState()
+    var chartExpanded by remember { mutableStateOf(true) }
 
     val currentIndex = state.months.indexOf(state.selectedMonth)
     val canGoPrev = currentIndex < state.months.size - 1
@@ -106,7 +115,38 @@ fun StatsScreen(viewModel: StatsViewModel = viewModel()) {
                 }
             }
 
-            Spacer(Modifier.height(24.dp))
+            // Last 7 days bar chart
+            if (state.weeklyTotals.isNotEmpty()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { chartExpanded = !chartExpanded }
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = "Last 7 Days",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Icon(
+                        imageVector = if (chartExpanded) Icons.Default.KeyboardArrowUp
+                                      else Icons.Default.KeyboardArrowDown,
+                        contentDescription = if (chartExpanded) "Collapse" else "Expand",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                AnimatedVisibility(visible = chartExpanded) {
+                    Column {
+                        WeekBarChart(
+                            days = state.weeklyTotals,
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                        )
+                        Spacer(Modifier.height(24.dp))
+                    }
+                }
+            }
 
             if (state.categoryTotals.isEmpty()) {
                 Box(

--- a/app/src/main/kotlin/com/nil/behisebe/ui/screens/stats/StatsViewModel.kt
+++ b/app/src/main/kotlin/com/nil/behisebe/ui/screens/stats/StatsViewModel.kt
@@ -6,21 +6,28 @@ import androidx.lifecycle.viewModelScope
 import com.nil.behisebe.BehisebeApp
 import com.nil.behisebe.data.model.Category
 import com.nil.behisebe.data.repository.ExpenseRepository
+import com.nil.behisebe.utils.toIso
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 
 data class CategoryTotal(val category: Category?, val total: Double)
+data class DayTotal(val date: String, val label: String, val amount: Double)
 
 data class StatsUiState(
     val months: List<String> = emptyList(),
     val selectedMonth: String = "",
     val categoryTotals: List<CategoryTotal> = emptyList(),
     val grandTotal: Double = 0.0,
+    val weeklyTotals: List<DayTotal> = emptyList(),
 )
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -31,12 +38,25 @@ class StatsViewModel(app: Application) : AndroidViewModel(app) {
     val months: StateFlow<List<String>> = repo.getDistinctMonths()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
+    private val weeklyTotalsFlow = repo.getAllWithCategory().map { all ->
+        val today = LocalDate.now()
+        (6 downTo 0).map { daysBack ->
+            val date = today.minusDays(daysBack.toLong())
+            val isoDate = date.toIso()
+            DayTotal(
+                date = isoDate,
+                label = date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+                amount = all.filter { it.expense.date == isoDate }.sumOf { it.expense.amount },
+            )
+        }
+    }
+
     val uiState: StateFlow<StatsUiState> = combine(
         months, selectedMonth
     ) { monthList, selected ->
         selected.ifEmpty { monthList.firstOrNull() ?: "" }
     }.flatMapLatest { activeMonth ->
-        combine(months, repo.getByMonthWithCategory(activeMonth)) { monthList, expenses ->
+        combine(months, repo.getByMonthWithCategory(activeMonth), weeklyTotalsFlow) { monthList, expenses, weekly ->
             val totals = expenses
                 .groupBy { it.category }
                 .map { (cat, items) -> CategoryTotal(cat, items.sumOf { it.expense.amount }) }
@@ -46,6 +66,7 @@ class StatsViewModel(app: Application) : AndroidViewModel(app) {
                 selectedMonth = activeMonth,
                 categoryTotals = totals,
                 grandTotal = expenses.sumOf { it.expense.amount },
+                weeklyTotals = weekly,
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), StatsUiState())


### PR DESCRIPTION
## Summary

- **Weekly bar chart** on Stats screen showing last 7 days of spending, with today highlighted and a collapsible toggle
- **Date-grouped expense list** on Home screen — sticky section headers with date label and day subtotal, replacing the flat list
- **Daily total card** on Home screen showing today's spending below the monthly total
- **Auto-color categories** — app picks the first unused color from a palette on category creation; no manual color picker
- **About screen** with app version, tech stack info, and description; accessible via info icon on Home top bar

## Test plan

- [ ] Add expenses on multiple dates → verify sticky date headers and day subtotals in Home list
- [ ] Check "Today" card shows correct daily total
- [ ] Open Stats → verify Last 7 Days bar chart renders with correct heights; today's bar is highlighted
- [ ] Tap the "Last 7 Days" header → chart collapses/expands
- [ ] Create multiple categories → each gets a unique color automatically
- [ ] Tap the ⓘ icon on Home → About screen opens with correct version (2.0.0) and back navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)